### PR TITLE
feat: hide NJ Transit API key

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use a lightweight Node.js image
-FROM node:16-alpine
+FROM node:18-alpine
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,17 +6,39 @@ const cors = require("cors");
 
 const app = express();
 app.use(cors()); // Enable CORS for all routes
+app.use(express.json());
 
-// Endpoint to return the API key
-app.get("/api/key", (req, res) => {
-  // Read the API key from environment variables
-  const apiKey = process.env.REACT_APP_NJTRANSIT_API_KEY;
+app.post("/api/train-data", async (req, res) => {
+  // Proxies requests to the NJ Transit API so the token isn't exposed to clients
+  const { trainNumber } = req.body;
+  if (!trainNumber) {
+    return res.status(400).json({ message: "trainNumber is required" });
+  }
 
-  // Send the API key as a JSON response
-  res.json({ apiKey });
+  try {
+    const formData = new FormData();
+    formData.append("token", process.env.REACT_APP_NJTRANSIT_API_KEY); // API key is kept server-side
+    formData.append("train", trainNumber);
+
+    const response = await fetch(
+      "https://raildata.njtransit.com/api/TrainData/getTrainStopList",
+      {
+        method: "POST",
+        headers: {
+          Accept: "text/plain",
+        },
+        body: formData,
+      }
+    );
+
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error("Error fetching train data:", err);
+    res.status(500).json({ message: "Failed to fetch train data" });
+  }
 });
 
-// Start the server
 const PORT = process.env.PORT || 5000; // Default to 5000 if PORT is not set
 app.listen(PORT, () => {
   console.log(`Backend server is running on port ${PORT}`);

--- a/src/components/PopularTrains.js
+++ b/src/components/PopularTrains.js
@@ -11,18 +11,6 @@ const PopularTrains = ({ onSelectTrain }) => {
     return (today === 0 || today === 6) ? weekendTrainNumbers : weekdayTrainNumbers;
   }, []);
 
-  // Fetch API key from external URL if undefined or null
-  const fetchApiKey = async () => {
-    try {
-      const response = await fetch('https://ontrack-docker-551821400291.us-central1.run.app/api/key');
-      const data = await response.json();
-      return data.apiKey;
-    } catch (err) {
-      console.error('Error fetching API key:', err);
-      return null;
-    }
-  };
-
   // Fetch data for the popular trains
   useEffect(() => {
     const handleResize = () => {
@@ -34,34 +22,16 @@ const PopularTrains = ({ onSelectTrain }) => {
   }, []);
 
   useEffect(() => {
-    const fetchTrainData = async (trainNumber) => { // Get train data from NJTransit API
-      let token = process.env.REACT_APP_NJTRANSIT_API_KEY;
-
-      if (!token) { // If token is not found in .env file
-        console.log('Local .env secret not found, using external URL');
-        token = await fetchApiKey(); // Fetch token from external URL
-        if (!token) { // If token is still not found
-          console.error('Token not found. Please check .env setup.');
-          return null;
-        }
-      }
-
-      const formData = new FormData();
-      formData.append('token', token);
-      formData.append('train', trainNumber);
-
+    const fetchTrainData = async (trainNumber) => { // Get train data from backend endpoint
       try {
-        const response = await fetch(
-          'https://raildata.njtransit.com/api/TrainData/getTrainStopList',
-          {
-            method: 'POST',
-            headers: {
-              'Accept': 'text/plain',
-            },
-            body: formData,
-          }
-        );
-        const data = await response.json();
+        const response = await fetch('/api/train-data', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ trainNumber }),
+        });
+        const data = await response.json(); // Waits for the API response and then converts it to json
         return data;
       } catch (err) {
         console.error(`Error fetching train ${trainNumber}:`, err);

--- a/src/components/TrainStatus.js
+++ b/src/components/TrainStatus.js
@@ -16,39 +16,21 @@ const TrainStatus = ({ initialTrainNumber = '' }) => {
 
   const trainStatusClass = 'TrainStatus';
 
-  const fetchTrainStopList = useCallback(async (number) => { // Gets train information from API
-    let token = process.env.REACT_APP_NJTRANSIT_API_KEY; // Get API token from .env file
-
-    if (!token) { // If token is not found in .env file
-      console.log('Local .env secret not found, using external URL');
-      token = await fetchApiKey(); // Fetch token from external URL
-      if (!token) { // If token is still not found
-        setError('Token not found. Please check .env setup.');
-        return;
-      }
-    }
-
+  const fetchTrainStopList = useCallback(async (number) => { // Gets train information from backend
     setLoading(true);
     setError('');
     setTrainData(null);
 
-    const formData = new FormData(); // Makes API request
-    formData.append('token', token);
-    formData.append('train', number);
-
     const startTime = Date.now(); // Record the start time
 
     try {
-      const response = await fetch(
-        'https://raildata.njtransit.com/api/TrainData/getTrainStopList',
-        {
-          method: 'POST',
-          headers: {
-            'Accept': 'text/plain',
-          },
-          body: formData,
-        }
-      );
+      const response = await fetch('/api/train-data', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ trainNumber: number }),
+      });
 
       const data = await response.json(); // Waits for the API response and then converts it to json
 
@@ -85,21 +67,9 @@ const TrainStatus = ({ initialTrainNumber = '' }) => {
     }
   }, [initialTrainNumber, fetchTrainStopList]);
 
-  const fetchApiKey = async () => {
-    try {
-      const response = await fetch('https://ontrack-docker-551821400291.us-central1.run.app/api/key');
-      const data = await response.json();
-      return data.apiKey;
-    } catch (err) {
-      console.error('Error fetching API key:', err);
-      return null;
-    }
-  };
-
   const handleSubmit = (e) => { // When the form is submitted, the entire page is prevented from reloading, and the train data is fetched
     e.preventDefault();
     if (!trainNumber) return; // Prevent submission if trainNumber is empty
-    console.log('REACT_APP_TEST:', process.env.REACT_APP_TEST);
     fetchTrainStopList(trainNumber);
   };
 


### PR DESCRIPTION
## Summary
- add backend POST endpoint for train data that forwards to NJ Transit API using env token
- call new endpoint from PopularTrains and TrainStatus components
- upgrade backend Dockerfile to Node 18 for built-in fetch and FormData
- restore helpful code comments and remove stray debug log

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d5e55cf083339285155fd96947a9